### PR TITLE
Improvement: Add progressively-enhanced safe-area insets

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -2,7 +2,14 @@ module.exports = {
   plugins: {
     'postcss-import': {},
     cssnano: {
-      preset: 'default',
+      preset: [
+        'default',
+        // Unsafe transform when considering cascade + fallbacks
+        // @see wepback.config.js
+        {
+          mergeLonghand: false,
+        },
+      ],
     },
   },
 };

--- a/src/styles/navigation.css
+++ b/src/styles/navigation.css
@@ -93,9 +93,15 @@ main {
       * Extra note:
       * All this runs a risk of "more" padding than needed, but it does have broader
       * support. See below for a more accurate version.
+      *
+      * Further complication:
+      * iOS will report safe-area-inset-bottom as 0px if viewport-fit is not cover
+      * This seems like a bad idea, because then the bottom bar will overlap the homebar,
+      * even though inset-bottom could have helped avoid that. Thus, we set 1rem for the
+      * syntax understood only by iOS.
     */
-    /** Legacy constant() (env()) syntax */
-    padding-bottom: calc(constant(safe-area-inset-bottom, 0px) + 0.5rem);
+    /** Legacy constant() (env()) syntax. */
+    padding-bottom: calc(constant(safe-area-inset-bottom, 0px) + 1rem);
     padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 0.5rem);
     justify-content: center;
   }
@@ -106,13 +112,15 @@ main {
    * This considers one case, in addition to the above:
    *  - safe-area-inset-bottom is supported, but is smaller than 0.5rem
    * 
-   * Silver lining: min, max and env() are supported in the relevant iOS/Safari
-   * versions, so this seems fine.
+   * Note: min, max and env() are supported in the relevant iOS/Safari
+   * versions, so this seems fine. As mentioned above, this also allows us
+   * to target versions that report inset-bottom of 0px when viewport-fit is not cover,
+   * but that should really be having >0.5rem margin
    * @see https://webkit.org/blog/7929/designing-websites-for-iphone-x/
    */
   @supports (padding: max(0px)) {
     .navigation-bar {
-      padding-bottom: max(0.5rem, env(safe-area-inset-bottom));
+      padding-bottom: max(1rem, env(safe-area-inset-bottom));
     }
   }
   /* When sticking to the bottom, the bar items are spaced around, 

--- a/src/styles/navigation.css
+++ b/src/styles/navigation.css
@@ -94,6 +94,8 @@ main {
       * All this runs a risk of "more" padding than needed, but it does have broader
       * support. See below for a more accurate version.
     */
+    /** Legacy const() syntax */
+    padding-bottom: calc(const(safe-area-inset-bottom, 0px) + 0.5rem);
     padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 0.5rem);
     justify-content: center;
   }

--- a/src/styles/navigation.css
+++ b/src/styles/navigation.css
@@ -84,6 +84,23 @@ main {
     padding: 0.5rem;
     justify-content: center;
   }
+  /* Progressively-enhance to use safe areas in iPhone X etc.
+   * Note: we need CSS math functions (max, here) to be supported, so
+   * we can pick the larger padding bottom, among the minimum and the inset.
+   * 
+   * This considers two cases:
+   *  - the user rotates the phone and the bottom safe area would be 0.
+   *  - safe-area-inset-bottom is supported, but is 0 (e.g. desktop Chrome)
+   * 
+   * Silver lining: min, max and env() are supported in the relevant iOS/Safari
+   * versions, so this seems fine.
+   * @see https://webkit.org/blog/7929/designing-websites-for-iphone-x/
+   */
+  @supports (padding: max(0px)) {
+    .navigation-bar {
+      padding-bottom: max(0.5rem, env(safe-area-inset-bottom));
+    }
+  }
   /* When sticking to the bottom, the bar items are spaced around, 
    * or evenly if supported.
    * The width is capped to a maximum;

--- a/src/styles/navigation.css
+++ b/src/styles/navigation.css
@@ -82,6 +82,7 @@ main {
     border-top-style: solid;
 
     padding: 0.5rem;
+
     /** Progressively-enhance safe area insets
       * - If env() is supported, set padding-bottom to
       *   env(safe-area-inset-bottom) + a minimum bottom padding.

--- a/src/styles/navigation.css
+++ b/src/styles/navigation.css
@@ -94,8 +94,8 @@ main {
       * All this runs a risk of "more" padding than needed, but it does have broader
       * support. See below for a more accurate version.
     */
-    /** Legacy const() syntax */
-    padding-bottom: calc(const(safe-area-inset-bottom, 0px) + 0.5rem);
+    /** Legacy constant() (env()) syntax */
+    padding-bottom: calc(constant(safe-area-inset-bottom, 0px) + 0.5rem);
     padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 0.5rem);
     justify-content: center;
   }

--- a/src/styles/navigation.css
+++ b/src/styles/navigation.css
@@ -82,15 +82,26 @@ main {
     border-top-style: solid;
 
     padding: 0.5rem;
+    /** Progressively-enhance safe area insets
+      * - If env() is supported, set padding-bottom to
+      *   env(safe-area-inset-bottom) + a minimum bottom padding.
+      * - If safe-area-inset-bottom is undefined, it is 0px
+      * - If env is not supported, this whole property is ignored, 
+      *   and the previous value (0.5rem) applies :tada:
+      *
+      * Extra note:
+      * All this runs a risk of "more" padding than needed, but it does have broader
+      * support. See below for a more accurate version.
+    */
+    padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 0.5rem);
     justify-content: center;
   }
   /* Progressively-enhance to use safe areas in iPhone X etc.
-   * Note: we need CSS math functions (max, here) to be supported, so
+   * Note: for this we need CSS math functions (max, here) to be supported, so
    * we can pick the larger padding bottom, among the minimum and the inset.
    * 
-   * This considers two cases:
-   *  - the user rotates the phone and the bottom safe area would be 0.
-   *  - safe-area-inset-bottom is supported, but is 0 (e.g. desktop Chrome)
+   * This considers one case, in addition to the above:
+   *  - safe-area-inset-bottom is supported, but is smaller than 0.5rem
    * 
    * Silver lining: min, max and env() are supported in the relevant iOS/Safari
    * versions, so this seems fine.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,10 +54,11 @@ module.exports = {
     }),
     new OptimizeCssAssetsPlugin({
       cssProcessor: cssnano,
-      cssProcessorOptions: {
-        discardComments: {
-          removeAll: true,
-        },
+      cssProcessorPluginOptions: {
+        // The mergeLonghand option is unsafe if we rely on the cascade for env() fallbacks,
+        // such as safe area insets for iPhone X
+        // @see https://github.com/cssnano/cssnano/issues/803
+        preset: ['default', {mergeLonghand: false}],
       },
       canPrint: false,
     }),


### PR DESCRIPTION
This might address #18 

The main issue seems to be how to define "inset safe areas", and also to be able to have "default" padding for other devices.
Fun bit of iPhone-driven CSS stuff, [this post by Webkit seems to cover it](https://webkit.org/blog/7929/designing-websites-for-iphone-x/)

Support matrix:
- Fot the inset areas, we need  [CSS env() variables](https://caniuse.com/#search=env). **If they are not supported, nothing bad happens**. 0.5rem remains from the previous declaration. Slightly larger padding due to addition.
- For a more accurate padding, we need the intersection of [CSS env() variables](https://caniuse.com/#search=env) and [CSS math functions](https://caniuse.com/#search=math%20fun). Essentially, this means iOS, and should work ok as an enhancement!
