### PR TITLE
Feature: Opt-in to viewport-fit=cover

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,11 +164,6 @@
           </noscript>
         </div>
       </main>
-      <footer>
-        <div class="pa3 flex-auto tc">
-          <span>Made by Fotis Papadogeorgopoulos</span>
-        </div>
-      </footer>
     </div>
 
     <script>

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en" dir="ltr">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
     <meta name="theme-color" content="#ffffff" />
     <meta

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "dev": "PORT=8080 npm-run-all clean setup build:copy-assets build:copy-root dev:webpack",
     "dev:watch": "npm-run-all --parallel dev:watch-elm dev:webpack",
-    "dev:webpack": "webpack-dev-server --port $PORT",
+    "dev:webpack": "webpack-dev-server --port $PORT --disable-host-check",
     "dev:watch-elm": "chokidar 'src/**/*.elm' -c 'elm make src/Main.elm --output dist/js/elm.js --debug' --initial",
     "prod": "npm-run-all build serve-prod",
     "prod-debug": "npm-run-all build-debug serve-prod",

--- a/src/Page.elm
+++ b/src/Page.elm
@@ -50,14 +50,14 @@ view { activePage, focusState, onBlurredMain, toOutMsg } { title, content } =
                 -- When focusing, set tabindex to -1
                 Focusing ->
                     [ id "main"
-                    , class "ph3 pb3 flex flex-column flex-auto"
+                    , class "flex flex-column flex-auto"
                     , tabindex -1
                     ]
 
                 -- When the user tabs past, then the state should be set to FocusPastMain
                 FocusOnMain ->
                     [ id "main"
-                    , class "ph3 pb3 flex flex-column flex-auto"
+                    , class "flex flex-column flex-auto"
                     , tabindex -1
                     , onBlur onBlurredMain
                     ]
@@ -65,7 +65,7 @@ view { activePage, focusState, onBlurredMain, toOutMsg } { title, content } =
                 -- In other cases, no need for focus attributes
                 _ ->
                     [ id "main"
-                    , class "ph3 pb3 flex flex-column flex-auto"
+                    , class "flex flex-column flex-auto"
                     ]
 
         viewMain =
@@ -76,7 +76,6 @@ view { activePage, focusState, onBlurredMain, toOutMsg } { title, content } =
         [ viewShell
             [ viewHeader activePage
             , viewMain [ Html.map toOutMsg content ]
-            , viewFooter
             ]
         ]
     }
@@ -88,7 +87,7 @@ viewShell children =
 
 viewHeader : Page -> Html msg
 viewHeader activePage =
-    header [ class "navigation-header pv2 bg-color-lighter color-text-faint bb lh-title" ]
+    header [ class "navigation-header bg-color-lighter color-text-faint bb lh-title" ]
         [ skipLink
         , nav [ class "navigation-container" ]
             [ div [ class "navigation-title-about flex items-center mw7" ]
@@ -154,12 +153,6 @@ viewNavBar page =
             , navLink Route.Settings "Settings" Feather.gear
             ]
         ]
-
-
-viewFooter : Html msg
-viewFooter =
-    -- The footer sets a safe area for the fixed bottom navigation
-    div [ class "footer" ] []
 
 
 isActive : Page -> Route -> Bool

--- a/src/styles/Page.css
+++ b/src/styles/Page.css
@@ -1,5 +1,5 @@
 /**
-  * CSS to handle how the navigation behaves
+  * CSS to handle how the core page layout behaves
 */
 
 /* Flexible navigation region, depending on screen height.
@@ -8,7 +8,10 @@
   * On tall and wide screens ?
   * On tall and narrow screens?
   * On short and wide screens?
-  * On short and narrow screens?
+  * On short andnarrow screens?
+  *
+  * NOTE: we also adjust for safe-area-inset-dir, based on which component
+  * contributes to layout based on the above
 */
 .navigation-header {
   padding-top: 0.5rem;

--- a/src/styles/Page.css
+++ b/src/styles/Page.css
@@ -21,7 +21,7 @@
 }
 @supports (padding: max(0px)) {
   .navigation-header {
-    padding-top: max(1rem, env(safe-area-inset-top));
+    padding-top: max(0.5rem, env(safe-area-inset-top));
   }
 }
 

--- a/src/styles/grid-entries.css
+++ b/src/styles/grid-entries.css
@@ -4,6 +4,7 @@
   grid-template-columns: repeat(auto-fill, minmax(14rem, 1fr));
   grid-auto-flow: dense;
   grid-gap: 1rem;
+  gap: 1rem;
 }
 
 .grid-entries--compact {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -10,7 +10,7 @@
 @import './enhanced-input.css';
 @import './grid-entries.css';
 @import './switch-toggle.css';
-@import './navigation.css';
+@import './Page.css';
 
 /** TODO: move to :root selector, whenever critters supports it */
 html {

--- a/src/styles/navigation.css
+++ b/src/styles/navigation.css
@@ -27,6 +27,7 @@
 /* Total pixel tweaking; set two columns, aligned start; Ephemeral | i */
 .navigation-title-about {
   display: grid;
+  grid-gap: 1rem;
   gap: 1rem;
   grid-template-columns: max-content 1fr;
   justify-items: start;
@@ -93,15 +94,9 @@ main {
       * Extra note:
       * All this runs a risk of "more" padding than needed, but it does have broader
       * support. See below for a more accurate version.
-      *
-      * Further complication:
-      * iOS will report safe-area-inset-bottom as 0px if viewport-fit is not cover
-      * This seems like a bad idea, because then the bottom bar will overlap the homebar,
-      * even though inset-bottom could have helped avoid that. Thus, we set 1rem for the
-      * syntax understood only by iOS.
     */
     /** Legacy constant() (env()) syntax. */
-    padding-bottom: calc(constant(safe-area-inset-bottom, 0px) + 1rem);
+    padding-bottom: calc(constant(safe-area-inset-bottom, 0px) + 0.5rem);
     padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 0.5rem);
     justify-content: center;
   }
@@ -110,7 +105,7 @@ main {
    * we can pick the larger padding bottom, among the minimum and the inset.
    * 
    * This considers one case, in addition to the above:
-   *  - safe-area-inset-bottom is supported, but is smaller than 0.5rem
+   *  - safe-area-inset-bottom is supported, and is > 0
    * 
    * Note: min, max and env() are supported in the relevant iOS/Safari
    * versions, so this seems fine. As mentioned above, this also allows us
@@ -120,7 +115,7 @@ main {
    */
   @supports (padding: max(0px)) {
     .navigation-bar {
-      padding-bottom: max(1rem, env(safe-area-inset-bottom));
+      padding-bottom: max(0.5rem, env(safe-area-inset-bottom));
     }
   }
   /* When sticking to the bottom, the bar items are spaced around, 

--- a/src/styles/navigation.css
+++ b/src/styles/navigation.css
@@ -10,15 +10,38 @@
   * On short and wide screens?
   * On short and narrow screens?
 */
+.navigation-header {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  padding-top: calc(constant(safe-area-inset-top, 0px) + 0.5rem);
+  padding-top: calc(env(safe-area-inset-top, 0px) + 0.5rem);
+}
+@supports (padding: max(0px)) {
+  .navigation-header {
+    padding-top: max(1rem, env(safe-area-inset-top));
+  }
+}
+
 /* Enhance from narrow -> wide screen */
 .navigation-container {
   display: flex;
   padding-left: 1rem;
   padding-right: 1rem;
+  padding-left: calc(constant(safe-area-inset-left, 0px) + 1rem);
+  padding-left: calc(env(safe-area-inset-left, 0px) + 1rem);
+  padding-right: calc(constant(safe-area-inset-right, 0px) + 1rem);
+  padding-right: calc(env(safe-area-inset-right, 0px) + 1rem);
   align-items: center;
   justify-content: space-between;
   text-align: center;
   overflow-x: auto;
+}
+/** If CSS math functions are supported, give more accurate padding */
+@supports (padding: max(0px)) {
+  .navigation-container {
+    padding-left: max(1rem, env(safe-area-inset-left));
+    padding-right: max(1rem, env(safe-area-inset-right));
+  }
 }
 /* Horizontal spacing without leftover space */
 .navigation-container > * + * {
@@ -39,7 +62,22 @@
   align-items: center;
 }
 main {
-  padding-top: 1rem;
+  padding: 1rem;
+  /** Progressively-enhanced padding left/right/bottom, based on env/constant support */
+  padding-left: calc(constant(safe-area-inset-left, 0px) + 1rem);
+  padding-left: calc(env(safe-area-inset-left, 0px) + 1rem);
+  padding-right: calc(constant(safe-area-inset-right, 0px) + 1rem);
+  padding-right: calc(env(safe-area-inset-right, 0px) + 1rem);
+  padding-bottom: calc(constant(safe-area-inset-bottom, 0px) + 1rem);
+  padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 1rem);
+}
+/** If CSS math functions are supported, give more accurate padding */
+@supports (padding: max(0px)) {
+  main {
+    padding-left: max(1rem, env(safe-area-inset-left));
+    padding-right: max(1rem, env(safe-area-inset-right));
+    padding-bottom: max(1rem, env(safe-area-inset-bottom));
+  }
 }
 /* Horizontal spacing without leftover space */
 .navigation-bar-flex > * + * {
@@ -96,6 +134,10 @@ main {
       * support. See below for a more accurate version.
     */
     /** Legacy constant() (env()) syntax. */
+    padding-left: calc(constant(safe-area-inset-left, 0px) + 0.5rem);
+    padding-left: calc(env(safe-area-inset-left, 0px) + 0.5rem);
+    padding-right: calc(constant(safe-area-inset-right, 0px) + 0.5rem);
+    padding-right: calc(env(safe-area-inset-right, 0px) + 0.5rem);
     padding-bottom: calc(constant(safe-area-inset-bottom, 0px) + 0.5rem);
     padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 0.5rem);
     justify-content: center;
@@ -116,6 +158,8 @@ main {
   @supports (padding: max(0px)) {
     .navigation-bar {
       padding-bottom: max(0.5rem, env(safe-area-inset-bottom));
+      padding-left: max(0.5rem, env(safe-area-inset-left));
+      padding-right: max(0.5rem, env(safe-area-inset-right));
     }
   }
   /* When sticking to the bottom, the bar items are spaced around, 
@@ -132,9 +176,11 @@ main {
     justify-content: space-around;
     justify-content: space-evenly;
   }
-  /* Set a safe area for the footer (and other content) */
-  .footer {
-    margin-bottom: 4rem;
+  /* Set a safe area for the footer (and other content), equal to 4rem (sticky) + inset-bottom */
+  main {
+    padding-bottom: 4rem;
+    padding-bottom: calc(constant(safe-area-inset-bottom, 0px) + 4rem);
+    padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 4rem);
   }
 }
 
@@ -148,6 +194,10 @@ main {
   }
   /** Safe area for main (more predictable like this, than sticky) */
   main {
+    /* Enough area for the header */
     padding-top: 4rem;
+    /* Enough area for the header + safe-area */
+    padding-top: calc(constant(safe-area-inset-top, 0px) + 4rem);
+    padding-top: calc(env(safe-area-inset-top, 0px) + 4rem);
   }
 }


### PR DESCRIPTION
`viewport-fit=cover` opts us in to webkit's "full screen" on iPhone X/XS/XR etc.
Safari will not insert automatic padding, and instead it's on us to use the env variables.

Some potential benefits:
- A slightly more spacious landscape view
- A slightly nicer-looking landscape view
- A more correct solution to bottom padding. Again, it seems wrong that Safari will report "0" for bottom padding if not opting in to full-screen, especially when it is always present

Things to check:
- [x] Left/right padding on container should be 1rem/calc(inset + 1rem)/max(inset, 1rem), enhancing accordingly
- [x] Same for header title + nav left/right padding
- [x] Container top padding should be header/calc(header+inset)
- [x] Container bottom padding should be ???
- [x] Header nav bottom padding should be 0.5rem/calc(inset-bottom+0.5rem)/max(inset-bottom, 0.5rem)