### PR TITLE
Improvement: Add types for leaflet plugins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,14 @@
         "@types/geojson": "*"
       }
     },
+    "@types/leaflet.markercluster": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@types/leaflet.markercluster/-/leaflet.markercluster-1.4.0.tgz",
+      "integrity": "sha512-ctCkUvknqzt+6eLOhZK7ta+G6WQ9wkTeFvOw1KhWYoPY/ZuzLD+QUg1Umnw7yzMNA+L00ne3cmTk/xmVNkRSLQ==",
+      "requires": {
+        "@types/leaflet": "*"
+      }
+    },
     "@types/nanoid": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/nanoid/-/nanoid-1.2.1.tgz",
@@ -2265,7 +2273,8 @@
                 "ansi-regex": {
                   "version": "2.1.1",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "aproba": {
                   "version": "1.2.0",
@@ -2680,7 +2689,8 @@
                 "safe-buffer": {
                   "version": "5.1.2",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "safer-buffer": {
                   "version": "2.1.2",
@@ -2736,6 +2746,7 @@
                   "version": "3.0.1",
                   "bundled": true,
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "ansi-regex": "^2.0.0"
                   }
@@ -2779,12 +2790,14 @@
                 "wrappy": {
                   "version": "1.0.2",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "yallist": {
                   "version": "3.0.3",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 }
               }
             }
@@ -2820,7 +2833,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -3235,7 +3249,8 @@
             "safe-buffer": {
               "version": "5.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -3291,6 +3306,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "2.1.1"
               }
@@ -3334,12 +3350,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
   },
   "dependencies": {
     "@types/leaflet": "^1.4.3",
+    "@types/leaflet.markercluster": "^1.4.0",
     "@types/nanoid": "^1.2.1",
     "idb": "^4.0.1",
     "idb-keyval": "^3.2.0",

--- a/src/@types/leaflet.featuregroup.subgroup.d.ts
+++ b/src/@types/leaflet.featuregroup.subgroup.d.ts
@@ -1,0 +1,21 @@
+import L from 'leaflet';
+// in the global namesapce "L"
+declare module 'leaflet' {
+  /** Class for SubGroup */
+  class SubGroup extends L.FeatureGroup {
+    /** Changes the parent group into which child markers are added to / removed from. */
+    setParentGroup(parentGroup: L.Layer): this;
+    /** Removes the current sub-group from map before changing the parent group. Re-adds the sub-group to map if it was before changing. */
+    setParentGroupSafe(parentGroup: L.Layer): this;
+    /** Returns the current parent group. */
+    getParentGroup(): L.Layer;
+  }
+
+  /** The factory is under leaflet.featureGroup.subGroup */
+  namespace featureGroup {
+    export function subGroup(
+      parentGroup?: L.Layer,
+      layersArray?: L.Layer[]
+    ): SubGroup;
+  }
+}

--- a/src/leaflet/leaflet-map.ts
+++ b/src/leaflet/leaflet-map.ts
@@ -176,8 +176,8 @@ class LeafletMap extends HTMLElement {
     this.observer.disconnect();
     this.map!.remove();
     this.map = null;
-    this.markersLayerGroup = null;
     this.markersFeatureGroup = null;
+    this.markersLayerGroup = null;
   }
 
   attributeChangedCallback(name: ObservedAttribute, oldVal: any, newVal: any) {
@@ -215,7 +215,9 @@ class LeafletMap extends HTMLElement {
                 this.setMapView();
               };
               (feature as any).removeFromLayerCb = (feature: L.Marker) => {
-                this.markersFeatureGroup!.removeLayer(feature);
+                if (this.markersFeatureGroup) {
+                  this.markersFeatureGroup!.removeLayer(feature);
+                }
                 this.setMapView();
               };
             }


### PR DESCRIPTION
The Leaflet plugins were previously untyped. Now the types correctly annotate the top-level `L`, and any new classes.