### PR TITLE
Bugfix/Infra: Use the correct invocation for navigation route

### DIFF
--- a/src/sw.js
+++ b/src/sw.js
@@ -1,5 +1,9 @@
 workbox.precaching.precacheAndRoute(self.__precacheManifest || []);
-workbox.routing.registerNavigationRoute('/');
+workbox.routing.registerNavigationRoute(
+  // Assuming '/index.html' has been precached,
+  // look up its corresponding cache key.
+  workbox.precaching.getCacheKeyForURL('/index.html')
+);
 
 // Listen for postMessage(), well, mesages
 self.addEventListener('message', messageEvent => {


### PR DESCRIPTION
Missed this in the Workbox v4 docs, about [needing to get a cache key for the navigation route](https://developers.google.com/web/tools/workbox/modules/workbox-routing)