### PR TITLE
Improvement: Show more accurate, actionable information when storing an entry fails

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -6,7 +6,6 @@
     "elm-version": "0.19.0",
     "dependencies": {
         "direct": {
-            "NoRedInk/elm-json-decode-pipeline": "1.0.0",
             "elm/browser": "1.0.1",
             "elm/core": "1.0.2",
             "elm/file": "1.0.5",

--- a/src/AddEntryForm.elm
+++ b/src/AddEntryForm.elm
@@ -400,6 +400,10 @@ viewError error =
                 --  - UnaccountedError (we messed up somewhere, probably)
                 --  - Any other RequestError variant (either internal, or a version mismatch, but I don't know if either is actionable)
                 SavingError requestError ->
+                    let
+                        internalError =
+                            text "We could not save the note locally, because of an internal error. It could be temporary, so you can try again later. If the error persists, please get in touch."
+                    in
                     case requestError of
                         Store.QuotaExceededError ->
                             -- TODO: Link to entries page here
@@ -420,11 +424,23 @@ viewError error =
                                     ]
                                 ]
 
+                        Store.InvalidStateError ->
+                            text "It is impossible to write to the local store. This is likely the browser not providing access to write. This can happen in some Private Mode sessions. If this error persists, please get in touch."
+
                         Store.UnaccountedError ->
                             text "We could not save the location locally, because of an unexpected error. This is possibly an error in the code. Please get in touch if you run into this!"
 
-                        _ ->
-                            text "We could not save the note locally, because of an internal error. It could be temporary, so you can try again later. If the error persists, please get in touch."
+                        Store.UnknownError ->
+                            internalError
+
+                        Store.VersionError ->
+                            internalError
+
+                        Store.AbortError ->
+                            internalError
+
+                        Store.ConstraintError ->
+                            internalError
     in
     div
         [ HA.tabindex -1

--- a/src/DarkMode.ts
+++ b/src/DarkMode.ts
@@ -94,7 +94,12 @@ function persistUserModePreference(mode: Mode) {
 }
 
 async function getUserModePreference() {
-  return idbKeyval.get<string | undefined>(STORE_KEY);
+  try {
+    const preference = await idbKeyval.get<string | undefined>(STORE_KEY);
+    return preference;
+  } catch (err) {
+    console.warn('Error in getUserModePreference', err);
+  }
 }
 
 async function setInitialDarkMode() {

--- a/src/DarkMode.ts
+++ b/src/DarkMode.ts
@@ -31,7 +31,7 @@ async function handleSubMessage(
   msg: FromElm
 ) {
   if (!msg.tag) {
-    console.error('No tag for msg', msg);
+    console.warn('No tag for msg', msg);
     return;
   }
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -42,7 +42,7 @@ type alias Model =
     , focusState : Page.FocusState
     , swUpdate : SW.SwUpdate
     , installPrompt : SW.InstallPrompt
-    , entries : RemoteData String (List Entry)
+    , entries : RemoteData Store.RequestError (List Entry)
     , darkMode : DarkMode.Mode
     , persistence : Maybe Persistence
     }

--- a/src/Page/Data.elm
+++ b/src/Page/Data.elm
@@ -376,6 +376,12 @@ humanRequestError err =
             , recovery = HumanError.Recoverable HumanError.TryAgain
             }
 
+        Store.InvalidStateError ->
+            { expectation = HumanError.Expected
+            , summary = Just "The import failed because it is impossible to write to the local store. This is likely the browser not providing access to write. This can happen in some Private Mode sessions. If this error persists, please get in touch."
+            , recovery = HumanError.Unrecoverable
+            }
+
         Store.UnaccountedError ->
             { expectation = HumanError.Unexpected
             , summary = Just "This is possibly an error in the code. Please get in touch if you run into this!"

--- a/src/Page/Data.elm
+++ b/src/Page/Data.elm
@@ -72,10 +72,10 @@ jsonMime =
 
 type Msg
     = -- Export
-      ClickedDownload (List Entry)
+      ClickedExport (List Entry)
     | GotDownloadTime (List Entry) Time.Posix
       -- Import
-    | FileUploadRequested
+    | FileImportRequested
     | FileSelected File
     | FileLoaded String
       -- Subscription to store (for Import)
@@ -100,11 +100,11 @@ update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
         -- Import/Export
-        ClickedDownload entries ->
+        ClickedExport entries ->
             -- Get the time, then save
             ( model, Task.perform (GotDownloadTime entries) Time.now )
 
-        FileUploadRequested ->
+        FileImportRequested ->
             ( model, requestFile )
 
         FileSelected file ->
@@ -221,7 +221,7 @@ viewExport entryData =
         (case entryData of
             RemoteData.Success entries ->
                 [ styledButtonBlue False
-                    [ onClick (ClickedDownload entries) ]
+                    [ onClick (ClickedExport entries) ]
                     [ text "Export Entries" ]
                 , details [ class "vs3 f4" ]
                     [ summary []
@@ -259,7 +259,7 @@ requestFile =
 -}
 viewImport : Html Msg
 viewImport =
-    div [ class "vs3" ] [ styledButtonBlue False [ onClick FileUploadRequested ] [ text "Import" ] ]
+    div [ class "vs3" ] [ styledButtonBlue False [ onClick FileImportRequested ] [ text "Import" ] ]
 
 
 viewUploadData : UploadData -> Html msg

--- a/src/Page/Data.elm
+++ b/src/Page/Data.elm
@@ -59,7 +59,7 @@ type alias Context =
 
 
 type alias EntryData =
-    RemoteData String (List Entry)
+    RemoteData Store.RequestError (List Entry)
 
 
 jsonMime =
@@ -228,14 +228,14 @@ viewExport entryData =
                         [ text "About the export format" ]
                     , paragraph
                         []
-                        [ text "The file will be downloaded in the JSON format. You can use this file to process your data in different ways, such as creating flash cards. You can also use this file to import data into this application on another device." ]
+                        [ text "The file will be exported in the JSON format. You can use this file to process your data in different ways, such as creating flash cards. You can also use this file to import data into this application on another device." ]
                     ]
                 ]
 
             _ ->
                 [ styledButtonBlue True
                     [ onClick <| NoOp ]
-                    [ text "Download Entries" ]
+                    [ text "Export Entries" ]
                 , paragraph [ class "measure" ] [ text "We have not loaded the entries yet, so we cannot save them." ]
                 ]
         )

--- a/src/Page/Home.elm
+++ b/src/Page/Home.elm
@@ -227,7 +227,6 @@ update msg model =
                         formResult =
                             entryRes
                                 |> Result.map (\entry -> ())
-                                |> Result.mapError (\err -> ())
 
                         ( newForm, cmd ) =
                             Form.update (Form.GotSaveResult formResult) model.form

--- a/src/Page/Home.elm
+++ b/src/Page/Home.elm
@@ -43,7 +43,7 @@ type alias Model =
 
 
 type alias Context =
-    { entries : RemoteData String (List Entry)
+    { entries : RemoteData Store.RequestError (List Entry)
     }
 
 
@@ -105,7 +105,7 @@ viewContent context model =
         ]
 
 
-viewEntries : RemoteData String (List Entry) -> ( String, String ) -> Html Msg
+viewEntries : RemoteData Store.RequestError (List Entry) -> ( String, String ) -> Html Msg
 viewEntries entryData entryTuple =
     case entryData of
         RemoteData.NotAsked ->
@@ -115,11 +115,11 @@ viewEntries entryData entryTuple =
             paragraph [ class "animated fadeIn delay h5" ] [ text "Loading entries..." ]
 
         RemoteData.Failure err ->
+            -- NOTE: We could try to expose more data here, but it doesn't seem too actionable.
+            -- This is a "get" request from a transaction, which mostly fails in "internal error" ways,
+            -- rather than, say, QuotaExceeded, which is actionable.
             div []
-                [ paragraph [] [ text "Error getting entries" ]
-                , pre []
-                    [ text err
-                    ]
+                [ paragraph [] [ text "We could not fetch the entries. This is likely temporary. Please try again later." ]
                 ]
 
         RemoteData.Success entries ->

--- a/src/Page/Map.elm
+++ b/src/Page/Map.elm
@@ -9,6 +9,7 @@ import Html.Events as HE exposing (onClick)
 import Html.Keyed as Keyed
 import Location as L
 import RemoteData exposing (RemoteData)
+import Store
 import Ui exposing (centeredContainerWide, heading, paragraph)
 
 
@@ -19,7 +20,7 @@ type alias Context =
 
 
 type alias EntryData =
-    RemoteData String (List Entry)
+    RemoteData Store.RequestError (List Entry)
 
 
 view : Context -> { title : String, content : Html msg }

--- a/src/Store.elm
+++ b/src/Store.elm
@@ -45,6 +45,9 @@ type RequestError
     | UnknownError
       -- If you try to open a database with a version lower than the one it already has.
     | VersionError
+      -- This can happen in the request, if we could not write to the database.
+      -- Probably browser related (mainly, that I've seen, Firefox Private Browsing)
+    | InvalidStateError
       -- An error we (as developers) have not accounted for.
       -- Possibly, the propagation of errors failed and we ended up wihout err.name.
     | UnaccountedError
@@ -215,6 +218,9 @@ requestErrorDecoder tag =
 
         "VersionError" ->
             JD.succeed VersionError
+
+        "InvalidStateError" ->
+            JD.succeed InvalidStateError
 
         "UnaccountedError" ->
             JD.succeed UnaccountedError

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -26,6 +26,7 @@ type RequestError =
   | 'QuotaExceededError'
   | 'UnknownError'
   | 'VersionError'
+  | 'InvalidStateError'
   // This one means it's on us!
   | 'UnaccountedError';
 
@@ -35,6 +36,7 @@ const knownRequestErrors: Array<RequestError> = [
   'QuotaExceededError',
   'UnknownError',
   'VersionError',
+  'InvalidStateError',
 ];
 
 function requestErrorFromUnknown(err: unknown): RequestError {

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -89,7 +89,7 @@ async function handleSubMessage(
   msg: FromElm
 ) {
   if (!msg.tag) {
-    console.error('No tag for msg', msg);
+    console.warn('No tag for msg', msg);
     return;
   }
 
@@ -129,7 +129,7 @@ async function handleSubMessage(
         }));
         sendToElm(GotEntries(entriesToElm));
       } catch (err) {
-        console.error('Unaccounted error in GotEntries', err);
+        console.error('TODO: handle error in GotEntries', err);
       }
       return;
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -8,8 +8,7 @@ import * as DarkMode from './DarkMode';
 import {Result} from './Core';
 
 export async function runWith(Elm_: typeof Elm) {
-  // TODO: Consider `await` to make the rest of the paints synchronous
-  // Perhaps we could use it to pass to Elm?
+  // Get the initial flags for starting the Elm app
   const initialDarkMode = await DarkMode.setInitialDarkMode();
 
   // Start Elm app
@@ -17,6 +16,7 @@ export async function runWith(Elm_: typeof Elm) {
 
   // PORTS
 
+  // TODO: Move these to ServiceWorker.ts
   // TO ELM
   const UpdateAvailable = {
     tag: 'UpdateAvailable',
@@ -128,6 +128,7 @@ export async function runWith(Elm_: typeof Elm) {
   }
 
   // GEOLOCATION <-> ELM
+  // TODO: Move these to Geolocation.ts
   const GotLocationMsg = (data: Result<LocationError, Location>) => ({
     tag: 'GotLocation',
     data,

--- a/src/client.ts
+++ b/src/client.ts
@@ -163,7 +163,12 @@ export async function runWith(Elm_: typeof Elm) {
   // Store <-> Elm
   app.ports.storeFromElm.subscribe(unkMsg => {
     let msg = unkMsg as Store.FromElm;
-    Store.handleSubMessage(app.ports.storeToElm.send, msg);
+    Store.handleSubMessage(app.ports.storeToElm.send, msg).catch(err => {
+      console.error(
+        'Unhandled error from Store.handleSubMessage. This should be impossible, but here we are.',
+        err
+      );
+    });
   });
 
   // DarkMode <-> Elm

--- a/src/client.ts
+++ b/src/client.ts
@@ -80,7 +80,7 @@ export async function runWith(Elm_: typeof Elm) {
       let msg = unkMsg as SWFromElm;
 
       if (!msg.tag) {
-        console.error('No tag for msg', msg);
+        console.warn('No tag for msg', msg);
         return;
       }
 
@@ -139,7 +139,7 @@ export async function runWith(Elm_: typeof Elm) {
   app.ports.geolocationFromElm.subscribe(unkMsg => {
     let msg = unkMsg as GeolocationFromElm;
     if (!msg.tag) {
-      console.error('No tag for msg', msg);
+      console.warn('No tag for msg', msg);
       return;
     }
 


### PR DESCRIPTION
Previously, we would show a "this is an internal error", well, error. Now we fail more accurately with `RequestError`, and include an explanation of it. It mashes together some errors ("Internal error" for IndexedDB Constraint/Version/Unknown), but I think it's better that way. The real actionable one is "QuotaExceededError".

Closes #3 
Closes #36 

Added some TODOs for cleanup in another PR.