### PR TITLE
Improve navigation performance (mostly seen on lower-powered devices)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -98,6 +98,21 @@
         "@types/leaflet": "*"
       }
     },
+    "@types/lodash": {
+      "version": "4.14.136",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.136.tgz",
+      "integrity": "sha512-0GJhzBdvsW2RUccNHOBkabI8HZVdOXmXbXhuKlDEd5Vv12P7oAVGfomGp3Ne21o5D/qu1WmthlNKFaoZJJeErA==",
+      "dev": true
+    },
+    "@types/lodash.debounce": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.6.tgz",
+      "integrity": "sha512-4WTmnnhCfDvvuLMaF3KV4Qfki93KebocUF45msxhYyjMttZDQYzHkO639ohhk8+oco2cluAFL3t5+Jn4mleylQ==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -6348,6 +6363,11 @@
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
       "dev": true
+    },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
     "lodash.memoize": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "author": "Fotis Papadogeorgopoulos <fotis@fpapado.com>",
   "license": "MPL-2.0",
   "devDependencies": {
+    "@types/lodash.debounce": "^4.0.6",
     "@types/node": "^12.0.12",
     "chokidar-cli": "^1.2.2",
     "critters-webpack-plugin": "^2.3.0",
@@ -83,6 +84,7 @@
     "leaflet": "^1.5.1",
     "leaflet.featuregroup.subgroup": "^1.0.2",
     "leaflet.markercluster": "^1.4.1",
+    "lodash.debounce": "^4.0.8",
     "nanoid": "^2.0.3",
     "pretty-bytes": "^5.2.0",
     "script-ext-html-webpack-plugin": "^2.1.3"

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -243,7 +243,7 @@ page loads to Assistive Technology users could be considered.
 -}
 delayedFocus : String -> Task Dom.Error ()
 delayedFocus id =
-    Process.sleep 100
+    Process.sleep 200
         |> Task.andThen (\() -> Dom.focus id)
 
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -26,7 +26,7 @@ import ServiceWorker as SW
 import Set exposing (Set)
 import Store
 import Store.Persistence as Persistence exposing (Persistence)
-import Task
+import Task exposing (Task)
 import Time
 import Ui exposing (..)
 import Url exposing (Url)
@@ -241,10 +241,19 @@ and might also help with not invalidating browser layout.
 NOTE: This is not necessarily the best strategy, and other ways of communicating
 page loads to Assistive Technology users could be considered.
 -}
-focus : String -> Cmd Msg
-focus id =
+delayedFocus : String -> Task Dom.Error ()
+delayedFocus id =
     Process.sleep 100
         |> Task.andThen (\() -> Dom.focus id)
+
+
+scrollTopAndFocusMain : Cmd Msg
+scrollTopAndFocusMain =
+    -- NOTE: It is important that we Dom.setViewport *before* the delayed focus
+    -- This allows setViewport to piggyback on the frist animation frame (rAF), before
+    -- the macro task (setTimeout) of Process.sleep, and the second rAF of Dom.focus
+    Dom.setViewport 0 0
+        |> Task.andThen (\() -> delayedFocus "main")
         |> Task.attempt GotFocusResult
 
 
@@ -259,7 +268,10 @@ update msg model =
             case urlRequest of
                 Browser.Internal url ->
                     ( { model | focusState = Focusing }
-                    , Cmd.batch [ Nav.pushUrl model.navKey (Url.toString url), focus "main" ]
+                    , Cmd.batch
+                        [ Nav.pushUrl model.navKey (Url.toString url)
+                        , scrollTopAndFocusMain
+                        ]
                     )
 
                 Browser.External href ->
@@ -281,7 +293,12 @@ update msg model =
             ( { model | focusState = FocusPastMain }, Cmd.none )
 
         ( UserPressedBack, _ ) ->
-            ( model, Cmd.batch [ Nav.back model.navKey 1, focus "main" ] )
+            ( model
+            , Cmd.batch
+                [ Nav.back model.navKey 1
+                , scrollTopAndFocusMain
+                ]
+            )
 
         ( ChangedUrl url, _ ) ->
             changeRouteTo (Route.fromUrl url) model

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -235,12 +235,16 @@ changeRouteTo maybeRoute model =
             ( { model | page = About }, Cmd.none )
 
 
-{-| Deferred focus after a setTimeout, to allow the rendering to settle
-TODO: Test this with Process.sleep 0 - 200ms
+{-| Set focus to an element, after a setTimeout, to allow the rendering to settle
+This is important for triggering some Screen Reader announcements correctly,
+and might also help with not invalidating browser layout.
+NOTE: This is not necessarily the best strategy, and other ways of communicating
+page loads to Assistive Technology users could be considered.
 -}
 focus : String -> Cmd Msg
 focus id =
-    Dom.focus id
+    Process.sleep 100
+        |> Task.andThen (\() -> Dom.focus id)
         |> Task.attempt GotFocusResult
 
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -243,7 +243,7 @@ page loads to Assistive Technology users could be considered.
 -}
 delayedFocus : String -> Task Dom.Error ()
 delayedFocus id =
-    Process.sleep 200
+    Process.sleep 100
         |> Task.andThen (\() -> Dom.focus id)
 
 

--- a/src/Page.elm
+++ b/src/Page.elm
@@ -51,14 +51,12 @@ view { activePage, focusState, onBlurredMain, onPressedBack, toOutMsg } { title,
                 -- When focusing, set tabindex to -1
                 Focusing ->
                     [ id "main"
-                    , class "flex flex-column flex-auto"
                     , tabindex -1
                     ]
 
                 -- When the user tabs past, then the state should be set to FocusPastMain
                 FocusOnMain ->
                     [ id "main"
-                    , class "flex flex-column flex-auto"
                     , tabindex -1
                     , onBlur onBlurredMain
                     ]
@@ -66,7 +64,6 @@ view { activePage, focusState, onBlurredMain, onPressedBack, toOutMsg } { title,
                 -- In other cases, no need for focus attributes
                 _ ->
                     [ id "main"
-                    , class "flex flex-column flex-auto"
                     ]
 
         viewMain =
@@ -83,7 +80,7 @@ view { activePage, focusState, onBlurredMain, onPressedBack, toOutMsg } { title,
 
 
 viewShell children =
-    div [ class "min-vh-100 flex flex-column bg-color-bg color-text f-phantomsans lh-copy elm-root" ] children
+    div [ class "min-vh-100 bg-color-bg color-text f-phantomsans lh-copy elm-root" ] children
 
 
 viewHeader : Page -> msg -> Html msg

--- a/src/Page/Home.elm
+++ b/src/Page/Home.elm
@@ -151,7 +151,7 @@ viewEntryKeyed ambiguousEntry =
     case ambiguousEntry of
         Entry.V1 entry ->
             ( Entry.Id.toString entry.id
-            , li [ class "flex flex-column pa3 br2 bg-color-lighter color-text ba bw1 b--color-faint shadow-4" ]
+            , li [ class "pa3 br2 bg-color-lighter color-text ba bw1 b--color-faint shadow-4" ]
                 [ div [ class "vs2 mb3" ]
                     [ paragraph [ class "fw6" ] [ text entry.front ]
                     , paragraph [] [ text entry.back ]

--- a/src/Page/Map.elm
+++ b/src/Page/Map.elm
@@ -33,9 +33,9 @@ view context =
 viewContent : Context -> Html msg
 viewContent { entries, darkMode } =
     centeredContainerWide
-        [ class "w-100 flex flex-column flex-grow-1" ]
+        [ class "w-100 ht-100" ]
         [ heading 1 [ class "visually-hidden" ] [ text "Map" ]
-        , viewMap [ class "flex flex-column flex-grow-1" ] darkMode entries
+        , viewMap [ class "ht-100" ] darkMode entries
         ]
 
 
@@ -60,7 +60,7 @@ viewMap attrs mode entryData =
         [ Keyed.node "leaflet-map"
             [ HA.attribute "defaultZoom" "8"
             , HA.attribute "theme" (String.toLower <| DarkMode.modeToString mode)
-            , class "flex flex-column flex-grow-1"
+            , class "ht-100"
             ]
             markerNodes
         ]

--- a/src/Page/NotFound.elm
+++ b/src/Page/NotFound.elm
@@ -14,7 +14,7 @@ view : { title : String, content : Html msg }
 view =
     { title = "Page Not Found"
     , content =
-        div [ class "flex flex-auto flex-column justify-center" ]
+        div [ class "" ]
             [ div
                 [ class "tc measure center vs4" ]
                 [ heading 1 [] [ text "Not Found :(" ]

--- a/src/leaflet/leaflet-map.ts
+++ b/src/leaflet/leaflet-map.ts
@@ -267,7 +267,9 @@ class LeafletMap extends HTMLElement {
       this.markersFeatureGroup.getLayers().length !== 0
     ) {
       // console.log('Will fit bounds');
-      this.map!.fitBounds(this.markersFeatureGroup!.getBounds(), {maxZoom: 12});
+      this.map!.fitBounds(this.markersFeatureGroup!.getBounds(), {
+        maxZoom: 12,
+      });
     }
     // Otherwise, set to the defined lat,lng
     else if (

--- a/src/leaflet/leaflet-map.ts
+++ b/src/leaflet/leaflet-map.ts
@@ -140,16 +140,32 @@ class LeafletMap extends HTMLElement {
 
     this.map = L.map(this.$mapContainer, {
       bounceAtZoomLimits: true,
+      // Do not include the default zoom; we customise it below
       zoomControl: false,
-    });
-    this.map.addControl(control.zoom({position: 'bottomright'}));
-    this.tileLayer = L.tileLayer(getTileUrl(this.theme), {
-      attribution:
-        'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.',
-      // id: 'stamen.toner',
-      maxZoom: 17,
+      // Do not include the default attribution; we customise it below
+      attributionControl: false,
     });
 
+    // Add a custom attribution control
+    // We do this because the default control only shows the 'Leaflet' prefix, before the tile layer's view
+    // has loaded. This is not ideal, because we `setView` in a deferred way. Thus, it leads to a flash
+    // of content and a small re-layout.
+    // It is not a big deal if the attribution is always visible (probably preferable anyway),
+    // so we enforce that by including the atttribution in the prefix
+    this.map.addControl(
+      control.attribution({
+        position: 'bottomright',
+        prefix:
+          '<a href="https://leafletjs.com">Leaflet</a> | Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.',
+      })
+    );
+    // Add the zoom controls to the bottom right; this should come after the attribution
+    this.map.addControl(control.zoom({position: 'bottomright'}));
+
+    // Add the tile layer to the map
+    this.tileLayer = L.tileLayer(getTileUrl(this.theme), {
+      maxZoom: 17,
+    });
     this.tileLayer.addTo(this.map);
 
     this.markersLayerGroup = L.markerClusterGroup();

--- a/src/leaflet/leaflet-map.ts
+++ b/src/leaflet/leaflet-map.ts
@@ -248,7 +248,7 @@ class LeafletMap extends HTMLElement {
 
   private setMapView() {
     // If we have features, fit the map around them
-    console.count('setMapView');
+    // console.count('setMapView');
     if (
       this.markersFeatureGroup &&
       this.markersFeatureGroup.getLayers().length !== 0

--- a/src/leaflet/leaflet-map.ts
+++ b/src/leaflet/leaflet-map.ts
@@ -21,9 +21,8 @@ const styleText = `
 }
 
 .container {
-  height: 32rem;
+  height: 80vh;
   background-color: var(--leaflet-map-bg) !important;
-  flex-grow: 1;
   contain: layout paint;
 }
 

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -87,3 +87,7 @@ html {
 .bg-warning {
   background-color: var(--color-warning);
 }
+
+leaflet-map {
+  contain: layout paint;
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -91,3 +91,7 @@ html {
 leaflet-map {
   contain: layout paint;
 }
+
+system-info {
+  contain: layout paint;
+}

--- a/src/styles/leaflet.css
+++ b/src/styles/leaflet.css
@@ -12,15 +12,15 @@
   display: flex !important;
   align-items: center;
   justify-content: center;
-  width: 44px !important;
-  height: 44px !important;
+  min-width: 44px !important;
+  min-height: 44px !important;
   line-height: 1 !important;
 }
 
-/* Propagate height for leaflet map */
 .leaflet-map-wrapper {
   background: #ddd;
 }
+
 /* Hide leaflet map if not defined */
 leaflet-map:not(:defined) {
   display: none;

--- a/src/system-info.ts
+++ b/src/system-info.ts
@@ -61,21 +61,17 @@ class SytemInfo extends HTMLElement {
   }
 
   private _getInfo(): InfoTuple[] {
-    const supportsStorage = 'storage' in navigator;
+    const supportsStorage = 'storage' in navigator ? 'yes' : 'no';
     const UA = window.navigator.userAgent;
     const standaloneMode = window.matchMedia('(display-mode: standalone)')
       .matches
       ? 'yes'
       : 'no';
-    const screenWidth = window.innerWidth;
-    const screenHeight = window.innerHeight;
-    const supportsCustomElements = 'customElements' in window;
+    const supportsCustomElements = 'customElements' in window ? 'yes' : 'no';
 
     return [
       ['Version', NOW_GITHUB_COMMIT_SHA],
       ['Standalone Mode', standaloneMode],
-      ['Screen Width', screenWidth],
-      ['Screen Height', screenHeight],
       ['Supports custom elements', supportsCustomElements],
       ['Supports StorageManager', supportsStorage],
       ['UA', UA],


### PR DESCRIPTION
This PR does a few things to improve the performance in navigation:
- Defer `.focus` to a macro task (100ms timeout). This alows the DOM to settle, and does not force a layout. This was the biggest improvement so far! It is also good for certain screen reader combinations to announce the focus better. Still some improvements there, but overal ok
- Set viewport to top. This is mostly a UX thing. One important bit is to sequence that before the focus, so that it can make use of the animation frame
- Batch and debounce the `.setView()` from leaflet `addToLayerCallback`. This means that the view is only set once, and within a certain time limit. Makes the initial paint seem more consistent (no animation from nowhere), and also eases the layout,
- Add [CSS Containment](https://www.youtube.com/watch?v=iqcO-5_KkJ4) of `layout paint` around `leaflet-map`. Did not seem to have a huge effect, if any, but I'd like it there for further benchmarking.