### PR TITLE
Improvement: Implement dialog pattern for update and install prompts

### DIFF
--- a/src/AddEntryForm.elm
+++ b/src/AddEntryForm.elm
@@ -366,7 +366,7 @@ view form_ =
                     ]
                     "Save location"
                 ]
-            , styledButtonBlue areFieldsReadOnly
+            , primaryActionButton areFieldsReadOnly
                 [ class "w-100" ]
                 [ text buttonText
                 ]

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -459,15 +459,25 @@ subscriptions model =
 
 viewUpdatePrompt : SW.SwUpdate -> Html Msg
 viewUpdatePrompt swUpdate =
-    notificationRegion []
+    let
+        headingId =
+            "update-prompt-heading"
+    in
+    div []
         [ SW.viewSwUpdate swUpdate
             { none = text ""
             , available =
                 calloutContainer [ class "z-9999" ]
-                    [ prompt []
+                    [ prompt
+                        [ HA.attribute "role" "dialog"
+                        , HA.attribute "aria-live" "polite"
+                        , HA.attribute "aria-labelledby" headingId
+                        ]
                         [ div [ class "measure mb2" ]
                             [ h2
-                                [ class "mv0 f-paragraph fw6 lh-title tc measure" ]
+                                [ HA.id headingId
+                                , class "mv0 f-paragraph fw6 lh-title tc measure"
+                                ]
                                 [ text "A new version is available. You can reload now to get it." ]
                             ]
                         , div [ class "flex" ]
@@ -490,15 +500,25 @@ viewUpdatePrompt swUpdate =
 
 viewInstallPrompt : SW.InstallPrompt -> Html Msg
 viewInstallPrompt installPrompt =
-    notificationRegion []
+    let
+        headingId =
+            "install-prompt-heading"
+    in
+    div []
         [ SW.viewInstallPrompt installPrompt
             { none = text ""
             , available =
                 calloutContainer [ class "z-9999" ]
-                    [ prompt []
+                    [ prompt
+                        [ HA.attribute "role" "dialog"
+                        , HA.attribute "aria-live" "polite"
+                        , HA.attribute "aria-labelledby" headingId
+                        ]
                         [ div [ class "measure mb2" ]
                             [ h2
-                                [ class "mv0 f-paragraph fw6 lh-title tc" ]
+                                [ HA.id headingId
+                                , class "mv0 f-paragraph fw6 lh-title tc"
+                                ]
                                 [ text "Add Ephemeral to your home screen?" ]
                             ]
                         , div [ class "flex" ]

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -461,21 +461,29 @@ viewUpdatePrompt : SW.SwUpdate -> Html Msg
 viewUpdatePrompt swUpdate =
     notificationRegion []
         [ SW.viewSwUpdate swUpdate
-            { none = div [] []
+            { none = text ""
             , available =
                 calloutContainer [ class "z-9999" ]
-                    [ prompt [ class "na2" ]
-                        [ div [ class "measure ma2" ]
-                            [ h2 [ class "mv0 f5 fw4 lh-title" ] [ text "A new version is available. You can reload now to get it." ]
+                    [ prompt []
+                        [ div [ class "measure mb2" ]
+                            [ h2
+                                [ class "mv0 f-paragraph fw6 lh-title tc measure" ]
+                                [ text "A new version is available. You can reload now to get it." ]
                             ]
-                        , div [ class "ma2 flex" ]
-                            [ styledButtonBlue False [ onClick AcceptUpdate, class "mr2" ] [ text "Reload" ]
-                            , styledButtonBlue False [ onClick DeferUpdate ] [ text "Later" ]
+                        , div [ class "flex" ]
+                            [ primaryActionButton
+                                False
+                                [ onClick AcceptUpdate, class "mr2 fw6" ]
+                                [ text "Reload" ]
+                            , secondaryActionButton
+                                False
+                                [ onClick DeferUpdate ]
+                                [ text "Later" ]
                             ]
                         ]
                     ]
-            , accepted = div [] []
-            , deferred = div [] []
+            , accepted = text ""
+            , deferred = text ""
             }
         ]
 
@@ -484,16 +492,24 @@ viewInstallPrompt : SW.InstallPrompt -> Html Msg
 viewInstallPrompt installPrompt =
     notificationRegion []
         [ SW.viewInstallPrompt installPrompt
-            { none = div [] []
+            { none = text ""
             , available =
                 calloutContainer [ class "z-9999" ]
-                    [ prompt [ class "na2" ]
-                        [ div [ class "measure ma2" ]
-                            [ h2 [ class "mv0 f5 fw4 lh-title" ] [ text "Add Ephemeral to your home screen?" ]
+                    [ prompt []
+                        [ div [ class "measure mb2" ]
+                            [ h2
+                                [ class "mv0 f-paragraph fw6 lh-title tc" ]
+                                [ text "Add Ephemeral to your home screen?" ]
                             ]
-                        , div [ class "ma2 flex" ]
-                            [ styledButtonBlue False [ onClick AcceptInstallPrompt, class "mr2" ] [ text "Add" ]
-                            , styledButtonBlue False [ onClick DeferInstallPrompt ] [ text "Dismiss" ]
+                        , div [ class "flex" ]
+                            [ primaryActionButton
+                                False
+                                [ onClick AcceptInstallPrompt, class "mr2" ]
+                                [ text "Add" ]
+                            , secondaryActionButton
+                                False
+                                [ onClick DeferInstallPrompt ]
+                                [ text "Dismiss" ]
                             ]
                         ]
                     ]

--- a/src/Page/Data.elm
+++ b/src/Page/Data.elm
@@ -220,7 +220,7 @@ viewExport entryData =
     div [ class "vs3" ]
         (case entryData of
             RemoteData.Success entries ->
-                [ styledButtonBlue False
+                [ primaryActionButton False
                     [ onClick (ClickedExport entries) ]
                     [ text "Export Entries" ]
                 , details [ class "vs3 f4" ]
@@ -233,7 +233,7 @@ viewExport entryData =
                 ]
 
             _ ->
-                [ styledButtonBlue True
+                [ primaryActionButton True
                     [ onClick <| NoOp ]
                     [ text "Export Entries" ]
                 , paragraph [ class "measure" ] [ text "We have not loaded the entries yet, so we cannot save them." ]
@@ -259,7 +259,7 @@ requestFile =
 -}
 viewImport : Html Msg
 viewImport =
-    div [ class "vs3" ] [ styledButtonBlue False [ onClick FileImportRequested ] [ text "Import" ] ]
+    div [ class "vs3" ] [ primaryActionButton False [ onClick FileImportRequested ] [ text "Import" ] ]
 
 
 viewUploadData : UploadData -> Html msg
@@ -430,7 +430,7 @@ viewPersistence persistence =
                 , paragraph [] [ text explanation ]
                 , case persistence of
                     Persistence.ShouldPrompt ->
-                        styledButtonBlue False
+                        primaryActionButton False
                             [ onClick RequestedPersistence ]
                             [ text "Persist data"
                             ]

--- a/src/Page/Data.elm
+++ b/src/Page/Data.elm
@@ -193,16 +193,16 @@ viewContent { entries, persistence } model =
                       Maybe.map viewPersistence persistence
                         |> Maybe.withDefault (text "")
                     ]
-                , section [ class "vs3" ]
+                , div [ class "vs3" ]
                     [ subHeading 2 [] [ text "Export" ]
                     , viewExport entries
                     ]
-                , section [ class "vs3" ]
+                , div [ class "vs3" ]
                     [ subHeading 2 [] [ text "Import" ]
                     , viewImport
                     , viewUploadData model.uploadData
                     ]
-                , section [ class "vs3" ]
+                , div [ class "vs3" ]
                     [ subHeading 2 [] [ text "Usage" ]
                     , viewUsage
                     ]

--- a/src/Page/Home.elm
+++ b/src/Page/Home.elm
@@ -94,12 +94,12 @@ viewContent context model =
                       else
                         About.viewPitch
                     ]
-                , section [] [ Html.map FormMsg (Form.view model.form) ]
-                , section [ class "vs3 vs4-ns" ]
+                , div [] [ Html.map FormMsg (Form.view model.form) ]
+                , div [ class "vs3 vs4-ns" ]
                     [ subHeading 2 [] [ text "Entries" ]
                     , viewEntries context.entries ( formInput.front, formInput.back )
                     ]
-                , section [] [ About.viewAddToHomeScreen ]
+                , div [] [ About.viewAddToHomeScreen ]
                 ]
             ]
         ]

--- a/src/Ui.elm
+++ b/src/Ui.elm
@@ -8,9 +8,10 @@ module Ui exposing
     , notificationRegion
     , paragraph
     , paragraphSmall
+    , primaryActionButton
     , prompt
+    , secondaryActionButton
     , styledButton
-    , styledButtonBlue
     , subHeading
     , subSubHeading
     , textbox
@@ -53,10 +54,10 @@ centeredContainerWide attrs children =
 
 
 styledButton attrs children =
-    button (class "pv2 ph3 button-reset focus-shadow br2 f4 fw5" :: attrs) children
+    button (class "pv2 ph3 button-reset focus-shadow br2 f-paragraph fw5" :: attrs) children
 
 
-styledButtonBlue isReadOnly attrs children =
+primaryActionButton isReadOnly attrs children =
     let
         cls =
             if isReadOnly then
@@ -68,8 +69,20 @@ styledButtonBlue isReadOnly attrs children =
     styledButton (class cls :: attrs) children
 
 
+secondaryActionButton isReadOnly attrs children =
+    let
+        cls =
+            if isReadOnly then
+                "bg-light-gray near-black"
+
+            else
+                "bg-light-gray near-black hover-bg-dark-gray hover-near-white"
+    in
+    styledButton (class cls :: attrs) children
+
+
 calloutContainer attrs children =
-    div (class "fixed bottom-0 left-0 w-100 br1" :: attrs)
+    div (class "fixed bottom-0 left-0 w-100" :: attrs)
         [ div [ class "mw6 center" ] children
         ]
 
@@ -87,7 +100,7 @@ notificationRegion attrs children =
 
 
 prompt attrs children =
-    div (class "pa3 flex flex-wrap justify-around items-center bg-color-lighter color-text shadow-1 animated fadeInUp" :: attrs) children
+    div (class "pa3 flex flex-wrap justify-around items-center bg-color-lighter color-text br1 shadow-1 animated fadeInUp" :: attrs) children
 
 
 paragraph attrs children =

--- a/src/styles/tachyons-with-extras.css
+++ b/src/styles/tachyons-with-extras.css
@@ -755,6 +755,10 @@ img {
 .hover-near-black:hover {
   color: #111;
 }
+.hover-near-white:focus,
+.hover-near-white:hover {
+  color: #f4f4f4;
+}
 .hover-light-blue:focus,
 .hover-light-blue:hover {
   color: #96ccff;
@@ -762,6 +766,10 @@ img {
 .hover-bg-light-blue:focus,
 .hover-bg-light-blue:hover {
   background-color: #96ccff;
+}
+.hover-bg-dark-gray:focus,
+.hover-bg-dark-gray:hover {
+  background-color: #999;
 }
 .pa0 {
   padding: 0;


### PR DESCRIPTION
Closes #43 

The update and install prompts could be considered a form of non-modal dialogs.
Non-modal dialogs prompt the user for an action, but keep the rest of the document navigable/reachable.

This a bit tricky! On the one hand, we want to communicate the region accurately. Previously, we only used a live region (`role="status" aria-live="polite"`) to make sure that the item gets announced. However, leaving actions in there means that the user has to infer them, and also find the region in the DOM. With a `dialog`, we can make that (presumably) more accurate.

One dilemma is whether the dialog should steal focus or not. Stealing focus prompts a choice more actively, but it is also known to be annoying and disorienting. A modal dialog gets the focus out of necessity. These dialogs... maybe are not so important. They are somewhere above cookie notices but below modals. So maybe let's try this PRs implementation, and seek to validate any assumptions before trying anything else.